### PR TITLE
Fixed DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class TelegrafMongoSession {
         bot.use((...args) => session.middleware(...args));
         
         const { MongoClient } = require('mongodb');
-        MongoClient.connect(mongo_url, { useNewUrlParser: true }).then((client) => {
+        MongoClient.connect(mongo_url, { useNewUrlParser: true, useUnifiedTopology: true }).then((client) => {
             const db = client.db();
             session = new TelegrafMongoSession(db, params);
         }).catch((reason) => { 


### PR DESCRIPTION
On the new version mongodb & mongodb driver has been warning:
DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to MongoClient.connect.