### PR TITLE
Expose connection promise from setup function

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,12 +44,12 @@ class TelegrafMongoSession {
     static setup(bot, mongo_url, params = {}) {
         let session;
         bot.use((...args) => session.middleware(...args));
-        
+
         const { MongoClient } = require('mongodb');
-        MongoClient.connect(mongo_url, { useNewUrlParser: true, useUnifiedTopology: true }).then((client) => {
+        return MongoClient.connect(mongo_url, { useNewUrlParser: true, useUnifiedTopology: true }).then((client) => {
             const db = client.db();
             session = new TelegrafMongoSession(db, params);
-        }).catch((reason) => { 
+        }).catch((reason) => {
             console.log('telegraf-session-mongodb: failed to connect to the database, session saving will not work.')
             console.log(reason);
 


### PR DESCRIPTION
I want to be able to run bot.launch() after mongo connection initialization

`
TelegrafMongoSession.setup(bot, process.env.DB_URL).then(() => {
  bot.launch();
})
`

Lack of such opportunity lead to errors like 
`
TypeError: Cannot read property 'middleware' of undefined
` 
This especially happens to me with Google Cloud Functions